### PR TITLE
AWS SageMaker Input Data Configuration

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -38,18 +38,19 @@ namespace LSC_Trainer
             this.btnSelectDataset = new System.Windows.Forms.Button();
             this.lblZipFile = new System.Windows.Forms.Label();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.btnSelectFolder = new System.Windows.Forms.Button();
             this.btnDownloadModel = new System.Windows.Forms.Button();
             this.btnRemoveFile = new System.Windows.Forms.Button();
             this.btnUploadToS3 = new System.Windows.Forms.Button();
-            this.txtOptimiser = new System.Windows.Forms.TextBox();
+            this.txtDevice = new System.Windows.Forms.TextBox();
             this.label24 = new System.Windows.Forms.Label();
-            this.txtWorkers = new System.Windows.Forms.TextBox();
+            this.txtOptimizer = new System.Windows.Forms.TextBox();
             this.label23 = new System.Windows.Forms.Label();
-            this.txtProject = new System.Windows.Forms.TextBox();
+            this.txtWorkers = new System.Windows.Forms.TextBox();
             this.label22 = new System.Windows.Forms.Label();
-            this.txtBatchSize = new System.Windows.Forms.TextBox();
+            this.txtPatience = new System.Windows.Forms.TextBox();
             this.label21 = new System.Windows.Forms.Label();
-            this.txtEpochs = new System.Windows.Forms.TextBox();
+            this.txtHyperparameters = new System.Windows.Forms.TextBox();
             this.label20 = new System.Windows.Forms.Label();
             this.label19 = new System.Windows.Forms.Label();
             this.btnTraining = new System.Windows.Forms.Button();
@@ -64,11 +65,11 @@ namespace LSC_Trainer
             this.label10 = new System.Windows.Forms.Label();
             this.label9 = new System.Windows.Forms.Label();
             this.label8 = new System.Windows.Forms.Label();
-            this.txtHyperparameters = new System.Windows.Forms.TextBox();
-            this.txtPatience = new System.Windows.Forms.TextBox();
+            this.txtData = new System.Windows.Forms.TextBox();
             this.txtWeights = new System.Windows.Forms.TextBox();
-            this.txtImgSize = new System.Windows.Forms.TextBox();
-            this.txtImgNum = new System.Windows.Forms.TextBox();
+            this.txtEpochs = new System.Windows.Forms.TextBox();
+            this.txtBatchSize = new System.Windows.Forms.TextBox();
+            this.txtImageSize = new System.Windows.Forms.TextBox();
             this.label7 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
@@ -76,7 +77,6 @@ namespace LSC_Trainer
             this.label3 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
-            this.btnSelectFolder = new System.Windows.Forms.Button();
             this.contextMenuStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.panel1.SuspendLayout();
@@ -137,7 +137,7 @@ namespace LSC_Trainer
             this.lblZipFile.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblZipFile.Location = new System.Drawing.Point(176, 226);
             this.lblZipFile.Name = "lblZipFile";
-            this.lblZipFile.Size = new System.Drawing.Size(107, 19);
+            this.lblZipFile.Size = new System.Drawing.Size(102, 18);
             this.lblZipFile.TabIndex = 3;
             this.lblZipFile.Text = "No file selected";
             // 
@@ -148,15 +148,15 @@ namespace LSC_Trainer
             this.panel1.Controls.Add(this.btnDownloadModel);
             this.panel1.Controls.Add(this.btnRemoveFile);
             this.panel1.Controls.Add(this.btnUploadToS3);
-            this.panel1.Controls.Add(this.txtOptimiser);
+            this.panel1.Controls.Add(this.txtDevice);
             this.panel1.Controls.Add(this.label24);
-            this.panel1.Controls.Add(this.txtWorkers);
+            this.panel1.Controls.Add(this.txtOptimizer);
             this.panel1.Controls.Add(this.label23);
-            this.panel1.Controls.Add(this.txtProject);
+            this.panel1.Controls.Add(this.txtWorkers);
             this.panel1.Controls.Add(this.label22);
-            this.panel1.Controls.Add(this.txtBatchSize);
+            this.panel1.Controls.Add(this.txtPatience);
             this.panel1.Controls.Add(this.label21);
-            this.panel1.Controls.Add(this.txtEpochs);
+            this.panel1.Controls.Add(this.txtHyperparameters);
             this.panel1.Controls.Add(this.label20);
             this.panel1.Controls.Add(this.label19);
             this.panel1.Controls.Add(this.btnTraining);
@@ -171,11 +171,11 @@ namespace LSC_Trainer
             this.panel1.Controls.Add(this.label10);
             this.panel1.Controls.Add(this.label9);
             this.panel1.Controls.Add(this.label8);
-            this.panel1.Controls.Add(this.txtHyperparameters);
-            this.panel1.Controls.Add(this.txtPatience);
+            this.panel1.Controls.Add(this.txtData);
             this.panel1.Controls.Add(this.txtWeights);
-            this.panel1.Controls.Add(this.txtImgSize);
-            this.panel1.Controls.Add(this.txtImgNum);
+            this.panel1.Controls.Add(this.txtEpochs);
+            this.panel1.Controls.Add(this.txtBatchSize);
+            this.panel1.Controls.Add(this.txtImageSize);
             this.panel1.Controls.Add(this.label7);
             this.panel1.Controls.Add(this.label6);
             this.panel1.Controls.Add(this.label5);
@@ -190,6 +190,16 @@ namespace LSC_Trainer
             this.panel1.Size = new System.Drawing.Size(925, 355);
             this.panel1.TabIndex = 4;
             this.panel1.Paint += new System.Windows.Forms.PaintEventHandler(this.panel1_Paint);
+            // 
+            // btnSelectFolder
+            // 
+            this.btnSelectFolder.Location = new System.Drawing.Point(213, 308);
+            this.btnSelectFolder.Name = "btnSelectFolder";
+            this.btnSelectFolder.Size = new System.Drawing.Size(176, 30);
+            this.btnSelectFolder.TabIndex = 43;
+            this.btnSelectFolder.Text = "Select Dataset (folder)";
+            this.btnSelectFolder.UseVisualStyleBackColor = true;
+            this.btnSelectFolder.Click += new System.EventHandler(this.btnSelectFolder_Click);
             // 
             // btnDownloadModel
             // 
@@ -222,92 +232,97 @@ namespace LSC_Trainer
             this.btnUploadToS3.UseVisualStyleBackColor = true;
             this.btnUploadToS3.Click += new System.EventHandler(this.btnUploadToS3_Click);
             // 
-            // txtOptimiser
+            // txtDevice
             // 
-            this.txtOptimiser.Location = new System.Drawing.Point(387, 183);
-            this.txtOptimiser.Name = "txtOptimiser";
-            this.txtOptimiser.Size = new System.Drawing.Size(107, 22);
-            this.txtOptimiser.TabIndex = 39;
+            this.txtDevice.Location = new System.Drawing.Point(480, 183);
+            this.txtDevice.Name = "txtDevice";
+            this.txtDevice.Size = new System.Drawing.Size(145, 22);
+            this.txtDevice.TabIndex = 39;
+            this.txtDevice.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // label24
             // 
             this.label24.AutoSize = true;
-            this.label24.Location = new System.Drawing.Point(302, 186);
+            this.label24.Location = new System.Drawing.Point(346, 186);
             this.label24.Name = "label24";
-            this.label24.Size = new System.Drawing.Size(72, 17);
+            this.label24.Size = new System.Drawing.Size(53, 16);
             this.label24.TabIndex = 38;
-            this.label24.Text = "Optimiser:";
+            this.label24.Text = "Device:";
             // 
-            // txtWorkers
+            // txtOptimizer
             // 
-            this.txtWorkers.Location = new System.Drawing.Point(387, 155);
-            this.txtWorkers.Name = "txtWorkers";
-            this.txtWorkers.Size = new System.Drawing.Size(107, 22);
-            this.txtWorkers.TabIndex = 37;
+            this.txtOptimizer.Location = new System.Drawing.Point(480, 155);
+            this.txtOptimizer.Name = "txtOptimizer";
+            this.txtOptimizer.Size = new System.Drawing.Size(145, 22);
+            this.txtOptimizer.TabIndex = 37;
+            this.txtOptimizer.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // label23
             // 
             this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(302, 158);
+            this.label23.Location = new System.Drawing.Point(346, 158);
             this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(65, 17);
+            this.label23.Size = new System.Drawing.Size(66, 16);
             this.label23.TabIndex = 36;
-            this.label23.Text = "Workers:";
+            this.label23.Text = "Optimizer:";
             // 
-            // txtProject
+            // txtWorkers
             // 
-            this.txtProject.Location = new System.Drawing.Point(387, 127);
-            this.txtProject.Name = "txtProject";
-            this.txtProject.Size = new System.Drawing.Size(107, 22);
-            this.txtProject.TabIndex = 35;
+            this.txtWorkers.Location = new System.Drawing.Point(480, 127);
+            this.txtWorkers.Name = "txtWorkers";
+            this.txtWorkers.Size = new System.Drawing.Size(145, 22);
+            this.txtWorkers.TabIndex = 35;
+            this.txtWorkers.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // label22
             // 
             this.label22.AutoSize = true;
-            this.label22.Location = new System.Drawing.Point(302, 130);
+            this.label22.Location = new System.Drawing.Point(346, 130);
             this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(56, 17);
+            this.label22.Size = new System.Drawing.Size(61, 16);
             this.label22.TabIndex = 34;
-            this.label22.Text = "Project:";
+            this.label22.Text = "Workers:";
             // 
-            // txtBatchSize
+            // txtPatience
             // 
-            this.txtBatchSize.Location = new System.Drawing.Point(387, 99);
-            this.txtBatchSize.Name = "txtBatchSize";
-            this.txtBatchSize.Size = new System.Drawing.Size(107, 22);
-            this.txtBatchSize.TabIndex = 33;
+            this.txtPatience.Location = new System.Drawing.Point(480, 99);
+            this.txtPatience.Name = "txtPatience";
+            this.txtPatience.Size = new System.Drawing.Size(145, 22);
+            this.txtPatience.TabIndex = 33;
+            this.txtPatience.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // label21
             // 
             this.label21.AutoSize = true;
-            this.label21.Location = new System.Drawing.Point(302, 102);
+            this.label21.Location = new System.Drawing.Point(346, 102);
             this.label21.Name = "label21";
-            this.label21.Size = new System.Drawing.Size(79, 17);
+            this.label21.Size = new System.Drawing.Size(63, 16);
             this.label21.TabIndex = 32;
-            this.label21.Text = "Batch Size:";
+            this.label21.Text = "Patience:";
             // 
-            // txtEpochs
+            // txtHyperparameters
             // 
-            this.txtEpochs.Location = new System.Drawing.Point(387, 71);
-            this.txtEpochs.Name = "txtEpochs";
-            this.txtEpochs.Size = new System.Drawing.Size(107, 22);
-            this.txtEpochs.TabIndex = 31;
+            this.txtHyperparameters.Location = new System.Drawing.Point(480, 71);
+            this.txtHyperparameters.Name = "txtHyperparameters";
+            this.txtHyperparameters.Size = new System.Drawing.Size(145, 22);
+            this.txtHyperparameters.TabIndex = 31;
+            this.txtHyperparameters.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // label20
             // 
             this.label20.AutoSize = true;
-            this.label20.Location = new System.Drawing.Point(302, 74);
+            this.label20.Location = new System.Drawing.Point(346, 74);
             this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(59, 17);
+            this.label20.Size = new System.Drawing.Size(116, 16);
             this.label20.TabIndex = 30;
-            this.label20.Text = "Epochs:";
+            this.label20.Text = "Hyperparameters:";
             // 
             // label19
             // 
             this.label19.AutoSize = true;
-            this.label19.Location = new System.Drawing.Point(651, 58);
+            this.label19.Location = new System.Drawing.Point(727, 41);
             this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(155, 17);
+            this.label19.Size = new System.Drawing.Size(150, 16);
             this.label19.TabIndex = 29;
             this.label19.Text = "TRAINING PROGRESS";
             // 
@@ -324,81 +339,81 @@ namespace LSC_Trainer
             // label18
             // 
             this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(784, 196);
+            this.label18.Location = new System.Drawing.Point(860, 179);
             this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(31, 17);
+            this.label18.Size = new System.Drawing.Size(30, 16);
             this.label18.TabIndex = 27;
             this.label18.Text = "N/A";
             // 
             // label17
             // 
             this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(784, 169);
+            this.label17.Location = new System.Drawing.Point(860, 152);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(31, 17);
+            this.label17.Size = new System.Drawing.Size(30, 16);
             this.label17.TabIndex = 26;
             this.label17.Text = "N/A";
             // 
             // label16
             // 
             this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(784, 142);
+            this.label16.Location = new System.Drawing.Point(860, 125);
             this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(31, 17);
+            this.label16.Size = new System.Drawing.Size(30, 16);
             this.label16.TabIndex = 25;
             this.label16.Text = "N/A";
             // 
             // label15
             // 
             this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(784, 115);
+            this.label15.Location = new System.Drawing.Point(860, 98);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(31, 17);
+            this.label15.Size = new System.Drawing.Size(30, 16);
             this.label15.TabIndex = 24;
             this.label15.Text = "N/A";
             // 
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(784, 88);
+            this.label14.Location = new System.Drawing.Point(860, 71);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(31, 17);
+            this.label14.Size = new System.Drawing.Size(30, 16);
             this.label14.TabIndex = 23;
             this.label14.Text = "N/A";
             // 
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(626, 196);
+            this.label13.Location = new System.Drawing.Point(702, 179);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(119, 17);
+            this.label13.Size = new System.Drawing.Size(113, 16);
             this.label13.TabIndex = 22;
             this.label13.Text = "Model Save Path:";
             // 
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(626, 169);
+            this.label12.Location = new System.Drawing.Point(702, 152);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(122, 17);
+            this.label12.Size = new System.Drawing.Size(112, 16);
             this.label12.TabIndex = 21;
             this.label12.Text = "Training Duration:";
             // 
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(626, 142);
+            this.label11.Location = new System.Drawing.Point(702, 125);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(152, 17);
+            this.label11.Size = new System.Drawing.Size(143, 16);
             this.label11.TabIndex = 20;
             this.label11.Text = "Virtual Machine Specs:";
             // 
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(626, 115);
+            this.label10.Location = new System.Drawing.Point(702, 98);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(102, 17);
+            this.label10.Size = new System.Drawing.Size(99, 16);
             this.label10.TabIndex = 19;
             this.label10.Text = "Upload Speed:";
             // 
@@ -406,9 +421,9 @@ namespace LSC_Trainer
             // 
             this.label9.AutoSize = true;
             this.label9.Cursor = System.Windows.Forms.Cursors.Default;
-            this.label9.Location = new System.Drawing.Point(626, 88);
+            this.label9.Location = new System.Drawing.Point(702, 71);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(139, 17);
+            this.label9.Size = new System.Drawing.Size(128, 16);
             this.label9.TabIndex = 18;
             this.label9.Text = "Connection duration:";
             // 
@@ -417,96 +432,101 @@ namespace LSC_Trainer
             this.label8.AutoSize = true;
             this.label8.Location = new System.Drawing.Point(84, 41);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(171, 17);
+            this.label8.Size = new System.Drawing.Size(168, 16);
             this.label8.TabIndex = 17;
             this.label8.Text = "TRAINING PARAMETERS";
             // 
-            // txtHyperparameters
+            // txtData
             // 
-            this.txtHyperparameters.Location = new System.Drawing.Point(178, 183);
-            this.txtHyperparameters.Name = "txtHyperparameters";
-            this.txtHyperparameters.Size = new System.Drawing.Size(107, 22);
-            this.txtHyperparameters.TabIndex = 16;
-            // 
-            // txtPatience
-            // 
-            this.txtPatience.Location = new System.Drawing.Point(178, 155);
-            this.txtPatience.Name = "txtPatience";
-            this.txtPatience.Size = new System.Drawing.Size(107, 22);
-            this.txtPatience.TabIndex = 15;
+            this.txtData.Location = new System.Drawing.Point(178, 183);
+            this.txtData.Name = "txtData";
+            this.txtData.Size = new System.Drawing.Size(145, 22);
+            this.txtData.TabIndex = 16;
+            this.txtData.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // txtWeights
             // 
-            this.txtWeights.Location = new System.Drawing.Point(178, 127);
+            this.txtWeights.Location = new System.Drawing.Point(178, 155);
             this.txtWeights.Name = "txtWeights";
-            this.txtWeights.Size = new System.Drawing.Size(107, 22);
-            this.txtWeights.TabIndex = 14;
+            this.txtWeights.Size = new System.Drawing.Size(145, 22);
+            this.txtWeights.TabIndex = 15;
+            this.txtWeights.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
-            // txtImgSize
+            // txtEpochs
             // 
-            this.txtImgSize.Location = new System.Drawing.Point(178, 99);
-            this.txtImgSize.Name = "txtImgSize";
-            this.txtImgSize.Size = new System.Drawing.Size(107, 22);
-            this.txtImgSize.TabIndex = 13;
+            this.txtEpochs.Location = new System.Drawing.Point(178, 127);
+            this.txtEpochs.Name = "txtEpochs";
+            this.txtEpochs.Size = new System.Drawing.Size(145, 22);
+            this.txtEpochs.TabIndex = 14;
+            this.txtEpochs.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
-            // txtImgNum
+            // txtBatchSize
             // 
-            this.txtImgNum.Location = new System.Drawing.Point(178, 71);
-            this.txtImgNum.Name = "txtImgNum";
-            this.txtImgNum.Size = new System.Drawing.Size(107, 22);
-            this.txtImgNum.TabIndex = 12;
+            this.txtBatchSize.Location = new System.Drawing.Point(178, 99);
+            this.txtBatchSize.Name = "txtBatchSize";
+            this.txtBatchSize.Size = new System.Drawing.Size(145, 22);
+            this.txtBatchSize.TabIndex = 13;
+            this.txtBatchSize.Click += new System.EventHandler(this.SelectAllTextOnClick);
+            // 
+            // txtImageSize
+            // 
+            this.txtImageSize.Location = new System.Drawing.Point(178, 71);
+            this.txtImageSize.Name = "txtImageSize";
+            this.txtImageSize.Size = new System.Drawing.Size(145, 22);
+            this.txtImageSize.TabIndex = 12;
+            this.txtImageSize.Click += new System.EventHandler(this.SelectAllTextOnClick);
             // 
             // label7
             // 
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(49, 182);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(122, 17);
+            this.label7.Size = new System.Drawing.Size(39, 16);
             this.label7.TabIndex = 11;
-            this.label7.Text = "Hyperparameters:";
+            this.label7.Text = "Data:";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
             this.label6.Location = new System.Drawing.Point(49, 155);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(71, 17);
+            this.label6.Size = new System.Drawing.Size(59, 16);
             this.label6.TabIndex = 10;
-            this.label6.Text = "Patience: ";
+            this.label6.Text = "Weights:";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(49, 128);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(63, 17);
+            this.label5.Size = new System.Drawing.Size(56, 16);
             this.label5.TabIndex = 9;
-            this.label5.Text = "Weights:";
+            this.label5.Text = "Epochs:";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(49, 101);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(81, 17);
+            this.label4.Size = new System.Drawing.Size(73, 16);
             this.label4.TabIndex = 8;
-            this.label4.Text = "Image Size:";
+            this.label4.Text = "Batch Size:";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(49, 74);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(127, 17);
+            this.label3.Size = new System.Drawing.Size(77, 16);
             this.label3.TabIndex = 7;
-            this.label3.Text = "Number of Images:";
+            this.label3.Text = "Image Size:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(143, 24);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(0, 17);
+            this.label2.Size = new System.Drawing.Size(0, 16);
             this.label2.TabIndex = 5;
             // 
             // label1
@@ -514,19 +534,9 @@ namespace LSC_Trainer
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(49, 228);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(93, 17);
+            this.label1.Size = new System.Drawing.Size(89, 16);
             this.label1.TabIndex = 4;
             this.label1.Text = "Selected File:";
-            // 
-            // btnSelectFolder
-            // 
-            this.btnSelectFolder.Location = new System.Drawing.Point(213, 308);
-            this.btnSelectFolder.Name = "btnSelectFolder";
-            this.btnSelectFolder.Size = new System.Drawing.Size(176, 30);
-            this.btnSelectFolder.TabIndex = 43;
-            this.btnSelectFolder.Text = "Select Dataset (folder)";
-            this.btnSelectFolder.UseVisualStyleBackColor = true;
-            this.btnSelectFolder.Click += new System.EventHandler(this.btnSelectFolder_Click);
             // 
             // Form1
             // 
@@ -562,11 +572,11 @@ namespace LSC_Trainer
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.TextBox txtHyperparameters;
-        private System.Windows.Forms.TextBox txtPatience;
+        private System.Windows.Forms.TextBox txtData;
         private System.Windows.Forms.TextBox txtWeights;
-        private System.Windows.Forms.TextBox txtImgSize;
-        private System.Windows.Forms.TextBox txtImgNum;
+        private System.Windows.Forms.TextBox txtEpochs;
+        private System.Windows.Forms.TextBox txtBatchSize;
+        private System.Windows.Forms.TextBox txtImageSize;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label label5;
@@ -584,15 +594,15 @@ namespace LSC_Trainer
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Button btnTraining;
         private System.Windows.Forms.Label label19;
-        private System.Windows.Forms.TextBox txtOptimiser;
+        private System.Windows.Forms.TextBox txtDevice;
         private System.Windows.Forms.Label label24;
-        private System.Windows.Forms.TextBox txtWorkers;
+        private System.Windows.Forms.TextBox txtOptimizer;
         private System.Windows.Forms.Label label23;
-        private System.Windows.Forms.TextBox txtProject;
+        private System.Windows.Forms.TextBox txtWorkers;
         private System.Windows.Forms.Label label22;
-        private System.Windows.Forms.TextBox txtBatchSize;
+        private System.Windows.Forms.TextBox txtPatience;
         private System.Windows.Forms.Label label21;
-        private System.Windows.Forms.TextBox txtEpochs;
+        private System.Windows.Forms.TextBox txtHyperparameters;
         private System.Windows.Forms.Label label20;
         private System.Windows.Forms.Button btnUploadToS3;
         private System.Windows.Forms.Button btnRemoveFile;

--- a/Form1.cs
+++ b/Form1.cs
@@ -75,7 +75,8 @@ namespace LSC_Trainer
                 txtPatience.Text = "100";
                 txtWorkers.Text = "8";
                 txtOptimizer.Text = "SGD";
-        }
+                // txtDevice.Text = "0";
+            }
             else
             {
                 txtImageSize.Text = "640";
@@ -87,6 +88,7 @@ namespace LSC_Trainer
                 txtPatience.Text = "100";
                 txtWorkers.Text = "8";
                 txtOptimizer.Text = "SGD";
+                // txtDevice.Text = "0";
             }
         }
 
@@ -172,6 +174,7 @@ namespace LSC_Trainer
             string patience = "";
             string workers = "";
             string optimizer = "";
+            string device = "";
 
             if (txtImageSize.Text != "")
             {
@@ -218,6 +221,11 @@ namespace LSC_Trainer
                 optimizer = txtOptimizer.Text;
             }
 
+            if (txtDevice.Text != "")
+            {
+                device = txtDevice.Text;
+            }
+
             string jobName = String.Format("Training-YOLOv5-UbuntuCUDAIMG-{0}", DateTime.Now.ToString("yyyy-MM-dd-hh-mmss"));
 
             CreateTrainingJobRequest trainingRequest = new CreateTrainingJobRequest()
@@ -240,6 +248,7 @@ namespace LSC_Trainer
                         "--patience", patience,
                         "--workers", workers,
                         "--optimizer", optimizer,
+                        // "--device", device
                     }
                 },
                 RoleArn = roleARN,

--- a/Form1.cs
+++ b/Form1.cs
@@ -20,6 +20,7 @@ namespace LSC_Trainer
         private readonly string ecrURI;
         private readonly string dockerImageURI;
         private readonly string s3DatasetURI;
+        private readonly string s3DestinationURI;
         private readonly string roleARN;
         public Form1()
         {
@@ -36,6 +37,7 @@ namespace LSC_Trainer
             ecrURI = Environment.GetEnvironmentVariable("ECR_URI");
             dockerImageURI = Environment.GetEnvironmentVariable("DOCKER_IMAGE_URI");
             s3DatasetURI = Environment.GetEnvironmentVariable("S3_DATASET_URI");
+            s3DestinationURI = Environment.GetEnvironmentVariable("S3_DESTINATION_URI");
             roleARN = Environment.GetEnvironmentVariable("ARN");
 
             amazonSageMakerClient = new AmazonSageMakerClient(accessKey, secretKey, RegionEndpoint.GetBySystemName(region));

--- a/Form1.cs
+++ b/Form1.cs
@@ -180,7 +180,7 @@ namespace LSC_Trainer
                 ResourceConfig = new ResourceConfig()
                 {
                     InstanceCount = 1,
-                    InstanceType = TrainingInstanceType.MlM4Xlarge,
+                    InstanceType = TrainingInstanceType.MlM5Xlarge,
                     VolumeSizeInGB = 12
                 },
                 TrainingJobName = jobName,

--- a/Form1.cs
+++ b/Form1.cs
@@ -96,9 +96,9 @@ namespace LSC_Trainer
             string img_size = "1280";
             string weights = "yolov5n6.pt";
             string patience = "100";
-            string hyperparameters = "hyp.scratch-low.yaml";
-            string epochs = "";
-            string batch_size = "";
+            string hyperparameters = "hyp.no-augmentation.yaml";
+            string epochs = "1";
+            string batch_size = "1";
             string project = "";
             string workers = "8";
             string optimiser = "SGD";

--- a/Form1.cs
+++ b/Form1.cs
@@ -92,7 +92,6 @@ namespace LSC_Trainer
 
         private void connectToolStripMenuItem1_Click(object sender, EventArgs e)
         {
-            ///TODO: To test if your AWS credentials is accessible and able to connect, execute this event with the AmazonSageMakerClient.
             try
             {
                 var response = amazonSageMakerClient.ListModelsAsync(new ListModelsRequest()).Result;
@@ -443,27 +442,6 @@ namespace LSC_Trainer
         {
             sender.GetType().GetMethod("SelectAll")?.Invoke(sender, null);
         }
-
-        ///TODO: Create a button to upload a dataset in .rar/.zip file.
-
-        ///TODO: Create a text area to get the training parameters:
-        ///TODO: number of images to train [NOT YET SURE/IMPLEMENTED IN YOLOV5 REPO]
-        ///TODO: image size (default 1280), batch size, epochs, 
-        ///TODO: weights (default yolov5n6.pt), project (default S3 destination), 
-        ///TODO: patience (default 100), workers (default 8), optimizer (default SGD), 
-        ///TODO: hyperparameters (default hyp.scratch-low.yamL)
-
-        ///TODO: Create a text area to print the ff:
-        ///TODO: 1. AmazonSageMakerClient connection duration.
-        ///TODO: 2. Dataset file size, and uploading network connectivity and duration
-        ///TODO: 3. Virtual machine specs used for training (the instance we selected to create the training job).
-        ///TODO: 4. Duration of the training in AWS SageMaker Training Job creation and training.
-        ///TODO: 5. Model url that was saved in AWS S3.
-
-        ///TODO: Create a proceed training button to create a training job in AWS.
-        ///TODO: Implement the create training job using SageMaker with the .env variable that contains the AWS ECR location 
-        ///TODO: of the team's training algorithm, specific EC2 Instance (Virtual Machine) that is free version, and other
-        ///TODO: specific configurations in the web interface that can be replicated here in AWSSDK.SageMaker.
 
     }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -184,7 +184,6 @@ namespace LSC_Trainer
                     VolumeSizeInGB = 12
                 },
                 TrainingJobName = jobName,
-                //HyperParameters = FileHandler.ReadYamlFile(hyperparameters),
                 StoppingCondition = new StoppingCondition()
                 {
                     MaxRuntimeInSeconds = 360000        

--- a/Form1.cs
+++ b/Form1.cs
@@ -212,7 +212,7 @@ namespace LSC_Trainer
                         "--batch", batch_size,
                         "--epochs", epochs,
                         "--weights", weights,
-                        "--data", sagemakerInputDataPath + "train/MMX059XA_COVERED5B.yaml",
+                        "--data", sageMakerInputDataPath + "train/MMX059XA_COVERED5B.yaml",
                         "--hyp", hyperparameters,
                     }
                 },

--- a/Form1.cs
+++ b/Form1.cs
@@ -62,6 +62,32 @@ namespace LSC_Trainer
 
             bucketName = s3URI.Replace("s3://", "");
             bucketName = bucketName.Replace("/", "");
+
+            string datasetName = s3DatasetURI.Split('/').Reverse().Skip(1).First();
+            if (datasetName == "MMX059XA_COVERED5B")
+            {
+                txtImageSize.Text = "1280";
+                txtBatchSize.Text = "1";
+                txtEpochs.Text = "1";
+                txtWeights.Text = "yolov5n6.pt";
+                txtData.Text = "MMX059XA_COVERED5B.yaml";
+                txtHyperparameters.Text = "hyp.no-augmentation.yaml";
+                txtPatience.Text = "100";
+                txtWorkers.Text = "8";
+                txtOptimizer.Text = "SGD";
+        }
+            else
+            {
+                txtImageSize.Text = "640";
+                txtBatchSize.Text = "1";
+                txtEpochs.Text = "50";
+                txtWeights.Text = "yolov5s.pt";
+                txtData.Text = "data.yaml";
+                txtHyperparameters.Text = "hyp.scratch-low.yaml";
+                txtPatience.Text = "100";
+                txtWorkers.Text = "8";
+                txtOptimizer.Text = "SGD";
+            }
         }
 
         private void connectToolStripMenuItem1_Click(object sender, EventArgs e)

--- a/Form1.cs
+++ b/Form1.cs
@@ -261,7 +261,7 @@ namespace LSC_Trainer
                 RoleArn = roleARN,
                 OutputDataConfig = new OutputDataConfig()
                 {
-                    S3OutputPath = s3DestinationURI + "output/",
+                    S3OutputPath = s3DestinationURI
                 },
                 ResourceConfig = new ResourceConfig()
                 {

--- a/Form1.cs
+++ b/Form1.cs
@@ -163,65 +163,59 @@ namespace LSC_Trainer
         }
         private void btnTraining_Click(object sender, EventArgs e)
         {
-            string img_num = "";
-            string img_size = "1280";
-            string weights = "yolov5n6.pt";
-            string patience = "100";
-            string hyperparameters = "hyp.no-augmentation.yaml";
-            string epochs = "1";
-            string batch_size = "1";
-            string project = "";
-            string workers = "8";
-            string optimiser = "SGD";
+            string img_size = "";
+            string batch_size = "";
+            string epochs = "";
+            string weights = "";
+            string data = "";
+            string hyperparameters = "";
+            string patience = "";
+            string workers = "";
+            string optimizer = "";
 
-            if(txtImgNum.Text != null || txtImgNum.Text != "")
+            if (txtImageSize.Text != "")
             {
-                img_num = txtImgNum.Text;
+                img_size = txtImageSize.Text;
             }
 
-            if (txtImgSize.Text != null || txtImgSize.Text != "")
-            {
-                img_size = txtImgSize.Text;
-            }
-
-            if (txtWeights.Text != null || txtWeights.Text != "")
-            {
-                weights = txtWeights.Text;
-            }
-
-            if (txtPatience.Text != null || txtPatience.Text != "")
-            {
-                patience = txtPatience.Text;
-            }
-
-            if (txtHyperparameters.Text != null || txtHyperparameters.Text != "")
-            {
-                hyperparameters = txtHyperparameters.Text;
-            }
-
-            if (txtEpochs.Text != null || txtEpochs.Text != "")
-            {
-                epochs = txtEpochs.Text;
-            }
-
-            if (txtBatchSize.Text != null || txtBatchSize.Text != "")
+            if (txtBatchSize.Text != "")
             {
                 batch_size = txtBatchSize.Text;
             }
 
-            if (txtProject.Text != null || txtProject.Text != "")
+            if (txtEpochs.Text != "")
             {
-                project = txtProject.Text;
+                epochs = txtEpochs.Text;
             }
 
-            if (txtWorkers.Text != null || txtWorkers.Text != "")
+            if (txtWeights.Text != "")
+            {
+                weights = txtWeights.Text;
+            }
+
+            if (txtData.Text != "")
+            {
+                data = txtData.Text;
+            }
+
+            if (txtHyperparameters.Text != "")
+            {
+                hyperparameters = txtHyperparameters.Text;
+            }
+
+            if (txtPatience.Text != "")
+            {
+                patience = txtPatience.Text;
+            }
+
+            if (txtWorkers.Text != "")
             {
                 workers = txtWorkers.Text;
             }
 
-            if (txtOptimiser.Text != null || txtOptimiser.Text != "")
+            if (txtOptimizer.Text != "")
             {
-                optimiser = txtOptimiser.Text;
+                optimizer = txtOptimizer.Text;
             }
 
             string jobName = String.Format("Training-YOLOv5-UbuntuCUDAIMG-{0}", DateTime.Now.ToString("yyyy-MM-dd-hh-mmss"));
@@ -239,10 +233,13 @@ namespace LSC_Trainer
                         "--batch", batch_size,
                         "--epochs", epochs,
                         "--weights", weights,
-                        "--data", sageMakerInputDataPath + "train/MMX059XA_COVERED5B.yaml",
+                        "--data", sageMakerInputDataPath + "train/" + data,
                         "--hyp", hyperparameters,
                         "--project", sageMakerOutputDataPath,
-                        "--name", name,
+                        "--name", "results",
+                        "--patience", patience,
+                        "--workers", workers,
+                        "--optimizer", optimizer,
                     }
                 },
                 RoleArn = roleARN,

--- a/Form1.cs
+++ b/Form1.cs
@@ -26,6 +26,8 @@ namespace LSC_Trainer
         private readonly string s3DatasetURI;
         private readonly string s3DestinationURI;
         private readonly string sageMakerInputDataPath = "/opt/ml/input/data/";
+        private readonly string sageMakerOutputDataPath = "/opt/ml/output/data/";
+        private readonly string sageMakerModelPath = "/opt/ml/model/";
         private readonly string roleARN;
         private readonly string bucketName;
         private readonly string uploadBucketName;
@@ -214,6 +216,8 @@ namespace LSC_Trainer
                         "--weights", weights,
                         "--data", sageMakerInputDataPath + "train/MMX059XA_COVERED5B.yaml",
                         "--hyp", hyperparameters,
+                        "--project", sageMakerOutputDataPath,
+                        "--name", name,
                     }
                 },
                 RoleArn = roleARN,

--- a/Form1.cs
+++ b/Form1.cs
@@ -192,15 +192,32 @@ namespace LSC_Trainer
                     new Channel()
                     {
                         ChannelName = "train",
-                        //ContentType = "application/x-recordio",
+                        InputMode = TrainingInputMode.File,
                         CompressionType = Amazon.SageMaker.CompressionType.None,
+                        RecordWrapperType = RecordWrapper.None,
                         DataSource = new DataSource()
                         {
-                            S3DataSource = new Amazon.SageMaker.Model.S3DataSource()
+                            S3DataSource = new S3DataSource()
                             {
-                                S3DataType = Amazon.SageMaker.S3DataType.S3Prefix,
-                                S3Uri = s3URI,
-                                S3DataDistributionType = Amazon.SageMaker.S3DataDistribution.FullyReplicated
+                                S3DataType = S3DataType.S3Prefix,
+                                S3Uri = s3DatasetURI + "train",
+                                S3DataDistributionType = S3DataDistribution.FullyReplicated
+                            }
+                        }
+                    },
+                    new Channel()
+                    {
+                        ChannelName = "val",
+                        InputMode = TrainingInputMode.File,
+                        CompressionType = Amazon.SageMaker.CompressionType.None,
+                        RecordWrapperType = RecordWrapper.None,
+                        DataSource = new DataSource()
+                        {
+                            S3DataSource = new S3DataSource()
+                            {
+                                S3DataType = S3DataType.S3Prefix,
+                                S3Uri = s3DatasetURI + "Verification Images",
+                                S3DataDistributionType = S3DataDistribution.FullyReplicated
                             }
                         }
                     }

--- a/Form1.cs
+++ b/Form1.cs
@@ -34,7 +34,7 @@ namespace LSC_Trainer
             string accessKey = Environment.GetEnvironmentVariable("ACCESS_KEY_ID");
             string secretKey = Environment.GetEnvironmentVariable("SECRET_ACCESS_KEY");
             string region = Environment.GetEnvironmentVariable("REGION");
-            s3URI = Environment.GetEnvironmentVariable("S3_URI");
+            //s3URI = Environment.GetEnvironmentVariable("S3_URI");
             ecrURI = Environment.GetEnvironmentVariable("ECR_URI");
             dockerImageURI = Environment.GetEnvironmentVariable("DOCKER_IMAGE_URI");
             s3DatasetURI = Environment.GetEnvironmentVariable("S3_DATASET_URI");

--- a/Form1.cs
+++ b/Form1.cs
@@ -25,6 +25,7 @@ namespace LSC_Trainer
         private readonly string dockerImageURI;
         private readonly string s3DatasetURI;
         private readonly string s3DestinationURI;
+        private readonly string sageMakerInputDataPath = "/opt/ml/input/data/";
         private readonly string roleARN;
         private readonly string bucketName;
         private readonly string uploadBucketName;

--- a/Form1.cs
+++ b/Form1.cs
@@ -18,6 +18,7 @@ namespace LSC_Trainer
         private readonly AmazonSageMakerRuntimeClient amazonSageMakerRuntimeClient;
         private readonly string s3URI;
         private readonly string ecrURI;
+        private readonly string dockerImageURI;
         private readonly string roleARN;
         public Form1()
         {
@@ -32,6 +33,7 @@ namespace LSC_Trainer
             string region = Environment.GetEnvironmentVariable("REGION");
             s3URI = Environment.GetEnvironmentVariable("S3_URI");
             ecrURI = Environment.GetEnvironmentVariable("ECR_URI");
+            dockerImageURI = Environment.GetEnvironmentVariable("DOCKER_IMAGE_URI");
             roleARN = Environment.GetEnvironmentVariable("ARN");
 
             amazonSageMakerClient = new AmazonSageMakerClient(accessKey, secretKey, RegionEndpoint.GetBySystemName(region));

--- a/Form1.cs
+++ b/Form1.cs
@@ -159,8 +159,18 @@ namespace LSC_Trainer
             {
                 AlgorithmSpecification = new AlgorithmSpecification()
                 {
+                    TrainingInputMode = "File",
                     TrainingImage = ecrURI,
-                    TrainingInputMode = "File"
+                    ContainerEntrypoint = new List<string>() { "python3", "yolov5/train.py" },
+                    ContainerArguments = new List<string>()
+                    {
+                        "--img-size", img_size,
+                        "--batch", batch_size,
+                        "--epochs", epochs,
+                        "--weights", weights,
+                        "--data", sagemakerInputDataPath + "train/MMX059XA_COVERED5B.yaml",
+                        "--hyp", hyperparameters,
+                    }
                 },
                 RoleArn = roleARN,
                 OutputDataConfig = new OutputDataConfig()

--- a/Form1.cs
+++ b/Form1.cs
@@ -34,6 +34,9 @@ namespace LSC_Trainer
 
         private string datasetPath;
         private bool isFile;
+
+        private string training_folder;
+        private string validation_folder;
         
         public Form1()
         {
@@ -76,6 +79,8 @@ namespace LSC_Trainer
                 txtWorkers.Text = "8";
                 txtOptimizer.Text = "SGD";
                 // txtDevice.Text = "0";
+                training_folder = "train";
+                validation_folder = "Verification Images";
             }
             else
             {
@@ -89,6 +94,8 @@ namespace LSC_Trainer
                 txtWorkers.Text = "8";
                 txtOptimizer.Text = "SGD";
                 // txtDevice.Text = "0";
+                training_folder = "train";
+                validation_folder = "val";
             }
         }
 
@@ -279,7 +286,7 @@ namespace LSC_Trainer
                             S3DataSource = new S3DataSource()
                             {
                                 S3DataType = S3DataType.S3Prefix,
-                                S3Uri = s3DatasetURI + "train",
+                                S3Uri = s3DatasetURI + training_folder,
                                 S3DataDistributionType = S3DataDistribution.FullyReplicated
                             }
                         }
@@ -295,7 +302,7 @@ namespace LSC_Trainer
                             S3DataSource = new S3DataSource()
                             {
                                 S3DataType = S3DataType.S3Prefix,
-                                S3Uri = s3DatasetURI + "Verification Images",
+                                S3Uri = s3DatasetURI + validation_folder,
                                 S3DataDistributionType = S3DataDistribution.FullyReplicated
                             }
                         }

--- a/Form1.cs
+++ b/Form1.cs
@@ -19,6 +19,7 @@ namespace LSC_Trainer
         private readonly string s3URI;
         private readonly string ecrURI;
         private readonly string dockerImageURI;
+        private readonly string s3DatasetURI;
         private readonly string roleARN;
         public Form1()
         {
@@ -34,6 +35,7 @@ namespace LSC_Trainer
             s3URI = Environment.GetEnvironmentVariable("S3_URI");
             ecrURI = Environment.GetEnvironmentVariable("ECR_URI");
             dockerImageURI = Environment.GetEnvironmentVariable("DOCKER_IMAGE_URI");
+            s3DatasetURI = Environment.GetEnvironmentVariable("S3_DATASET_URI");
             roleARN = Environment.GetEnvironmentVariable("ARN");
 
             amazonSageMakerClient = new AmazonSageMakerClient(accessKey, secretKey, RegionEndpoint.GetBySystemName(region));

--- a/Form1.cs
+++ b/Form1.cs
@@ -175,7 +175,7 @@ namespace LSC_Trainer
                 RoleArn = roleARN,
                 OutputDataConfig = new OutputDataConfig()
                 {
-                    S3OutputPath = s3URI
+                    S3OutputPath = s3DestinationURI + "output/",
                 },
                 ResourceConfig = new ResourceConfig()
                 {

--- a/Form1.cs
+++ b/Form1.cs
@@ -413,6 +413,11 @@ namespace LSC_Trainer
             }
         }
 
+        private void SelectAllTextOnClick(object sender, EventArgs e)
+        {
+            sender.GetType().GetMethod("SelectAll")?.Invoke(sender, null);
+        }
+
         ///TODO: Create a button to upload a dataset in .rar/.zip file.
 
         ///TODO: Create a text area to get the training parameters:

--- a/Form1.cs
+++ b/Form1.cs
@@ -22,6 +22,7 @@ namespace LSC_Trainer
         private readonly string s3DatasetURI;
         private readonly string s3DestinationURI;
         private readonly string roleARN;
+        private readonly string sagemakerInputDataPath = "/opt/ml/input/data/";
         public Form1()
         {
             InitializeComponent();

--- a/Form1.cs
+++ b/Form1.cs
@@ -153,7 +153,7 @@ namespace LSC_Trainer
                 optimiser = txtOptimiser.Text;
             }
 
-            string jobName = String.Format("Training-YOLOv5-{0}", DateTime.Now.ToString("yyyy-MM-dd-hh-mmss"));
+            string jobName = String.Format("Training-YOLOv5-UbuntuCUDAIMG-{0}", DateTime.Now.ToString("yyyy-MM-dd-hh-mmss"));
 
             CreateTrainingJobRequest trainingRequest = new CreateTrainingJobRequest()
             {


### PR DESCRIPTION
This PR is responsible for the following development:
1. Setting the input channels which are `train` and `val` to be used for the training.
2. Setting the `ContainerEntrypoint` and `ContainerArguments`.
3. Customizing inputs to be used for training parameters (only image size, batch size, epochs, weights, hyperparameters for now).
4. Pre-defining `sagemakerInputDataPath` in order to locate the `.yaml` file inside the `train` channel path.